### PR TITLE
Fix HTML rendering in book reviews to display line breaks correctly

### DIFF
--- a/views/book-detail.pug
+++ b/views/book-detail.pug
@@ -41,7 +41,7 @@ block content
             .book-review-section
               h2.review-heading My Review
               .review-content
-                p= book.review
+                p!= book.review
           else
             .no-review
               p.empty-state I haven't written a review for this book yet.


### PR DESCRIPTION
Change review output from escaped (=) to unescaped (!=) in book-detail.pug to render <br> tags as actual line breaks instead of displaying them as text.