### PR TITLE
Fix Mixture of Experts project ID collision with TimmyOrTroye

### DIFF
--- a/data.json
+++ b/data.json
@@ -452,7 +452,7 @@
             ]
         },
         {
-        "id": "21",
+        "id": "22",
         "category": "ai",
         "project_name": "Mixture of Experts: LLM-as-Judge",
         "description": "A Python/Jupyter implementation of a Mixture of Experts evaluation system where multiple frontier LLMs (GPT, Claude, Gemini, DeepSeek, Llama) each answer a challenging question and then act as judges to rank each other's responses. Final rankings are aggregated by average score across all judges, demonstrating how ensemble evaluation improves over single-judge assessment.",


### PR DESCRIPTION
Change ID from 21 to 22 to avoid conflict with the TimmyOrTroye project that already exists on the master branch.