### PR TITLE
Add dedicated AI/ML tab with subcategories and redesign bio skills la…

### DIFF
--- a/app.js
+++ b/app.js
@@ -314,11 +314,15 @@ app.get('/', (req, res) => {
 })
 
 app.get('/projects', (req, res) => {
-    const { projects, categories, pmProjects } = data;
-    res.render('index', { 
-        projects, 
-        categories, 
+    const { projects, categories, pmProjects, aiSubcategories } = data;
+    const aiProjects = projects.filter(p => p.category === 'ai');
+    const engineeringProjects = projects.filter(p => p.category !== 'ai');
+    res.render('index', {
+        projects: engineeringProjects,
+        categories,
         pmProjects,
+        aiSubcategories,
+        aiProjects,
         pageTitle: "Projects - Cam Dresie | Product & Engineering Portfolio",
         pageDescription: "Explore Cam Dresie's product management and engineering projects. AI-powered legal technology solutions, team leadership initiatives, and technical implementations."
     });

--- a/data.json
+++ b/data.json
@@ -1,10 +1,19 @@
 {
-    "categories": [
+    "aiSubcategories": [
         {
-            "id": "ai",
-            "name": "AI & Machine Learning",
-            "description": "Projects focusing on artificial intelligence and algorithms"
+            "id": "agentic",
+            "name": "Agentic AI & GenAI"
         },
+        {
+            "id": "dl",
+            "name": "Deep Learning & Computer Vision"
+        },
+        {
+            "id": "classical",
+            "name": "Classical AI & Algorithms"
+        }
+    ],
+    "categories": [
         {
             "id": "passion",
             "name": "Passion Projects",
@@ -73,6 +82,7 @@
         {
         "id": "2",
             "category": "ai",
+            "aiSubcategory": "classical",
         "project_name": "Domino Game AI - Minimax With Alpha-Beta Pruning",
         "description": "This is a project I did for my AI class at UPenn. This project implements a minimax algorithm with alpha-beta pruning to create an AI that is capable of playing a dominoes game. The game is played by two players, one a human and the other the AI. One player always places dominoes vertically, the other horizontally. The AI allows a player to enter a number to specify how many moves ahead it should search in the minimax tree of possibilities, 1 being the least and 9 the most. If the game looks 9 moves into the future, it is exceedingly hard to beat. It examines all possible outcomes to determine the most optimal play for it, assuming fully optimal play by the human player. If the human player makes an error, it is even easier for the AI to win. Code available on request.",
         "technologies": [
@@ -91,6 +101,7 @@
         {
         "id": "21",
             "category": "ai",
+            "aiSubcategory": "dl",
         "project_name": "Timmy or Troye - Deep Learning Image Classifier",
         "description": "A deep learning image classifier built with fastai and PyTorch that distinguishes between Timothée Chalamet, Troye Sivan, and Timmy Turner from Fairly Odd Parents. The project uses DuckDuckGo image search to automatically build a training dataset, then fine-tunes a pretrained ResNet18 convolutional neural network to classify images across the three categories. The model achieves near-perfect accuracy on the validation set after just 6 epochs of fine-tuning, demonstrating the power of transfer learning for rapid computer vision prototyping.",
         "technologies": [
@@ -475,6 +486,7 @@
         {
         "id": "22",
         "category": "ai",
+        "aiSubcategory": "agentic",
         "project_name": "Mixture of Experts: LLM-as-Judge",
         "description": "A Python/Jupyter implementation of a Mixture of Experts evaluation system where multiple frontier LLMs (GPT, Claude, Gemini, DeepSeek, Llama) each answer a challenging question and then act as judges to rank each other's responses. Final rankings are aggregated by average score across all judges, demonstrating how ensemble evaluation improves over single-judge assessment.",
         "technologies": [
@@ -498,6 +510,7 @@
         {
         "id": "23",
         "category": "ai",
+        "aiSubcategory": "agentic",
         "project_name": "RAG Career Agent",
         "description": "An AI-powered career agent embedded in my portfolio site that answers questions about my background, projects, skills, and experience. Built with a Retrieval-Augmented Generation (RAG) architecture, the agent uses OpenAI embeddings and FAISS vector search to semantically retrieve the most relevant information from my resume, LinkedIn profile, portfolio projects, leadership philosophy, career timeline, and blog posts before generating responses. The agent includes OpenAI function calling for recording visitor contact details and unanswered questions via Pushover notifications, and is deployed on Hugging Face Spaces with a floating chat widget integrated into every page of the portfolio.",
         "technologies": [

--- a/views/bio.pug
+++ b/views/bio.pug
@@ -14,19 +14,8 @@ block content
             p.bio-subtitle Group Product Manager | Attorney | AI & Legal Tech Leader
 
         .portfolio-content
-          .grid-x.grid-margin-x
-            .cell.small-12.medium-8.large-8
-              .portfolio-bio
-                p
-                  | As Group Product Manager at Ontra for our flagship product, Contract Automation, I champion innovation through agentic AI solutions — building systems where LLMs autonomously orchestrate complex, multi-step legal workflows — and robust product management. I believe great products come from high-trust teams with clear outcomes and room to create. The teams I lead excel at turning complex customer problems into shipped, impactful solutions.
-                p
-                  | I invest in people: candid feedback, visible expectations, and career coaching are baked into our operating rhythms. The result is a culture that experiments, has freedom to fail, learns quickly, and consistently delivers business impact. Known for my inspiring leadership style and clear communication, I ensure that our products exceed customer expectations through strategic product vision and execution on that vision.
-                p
-                  | My technical acumen and background in business and legal domains allow me to adeptly navigate complex challenges, giving me a unique edge in crafting product strategy. I actively build with agentic AI frameworks like LangChain, LangGraph, and Claude Agents, bridging PM strategy and hands-on AI engineering in a way few product leaders can. My management style empowers teams to excel, fostering a culture of transparency, innovation, and relentless pursuit of excellence.
-                p
-                  | Outside the office, I’m an avid hiker, runner, and reader, with a particular fondness for Walter Isaacson's biography of Leonardo Da Vinci. I also love spending time with my husband, attending concerts, and spending quality time with our family Labradoodle, Koda.
-            
-            .cell.portfolio-meta.small-12.medium-4.large-4
+          .skills-section
+            .skills-columns
               .skills-container.ai-skills
                 h6 AI & Agentic Development
                 .skills-grid
@@ -38,71 +27,58 @@ block content
                   span.skill-tag.ai-skill Cursor
                   span.skill-tag.ai-skill Prompt Engineering
                   span.skill-tag.ai-skill LLM Orchestration
-                  span.skill-tag.ai-skill Retrieval-Augmented Generation
+                  span.skill-tag.ai-skill RAG
                   span.skill-tag.ai-skill Tool Use & Function Calling
-                  span.skill-tag.ai-skill Multi-step AI Workflows
                   span.skill-tag.ai-skill Agentic AI Systems
-                  span.skill-tag.ai-skill MCP (Model Context Protocol)
+                  span.skill-tag.ai-skill MCP
                   span.skill-tag.ai-skill Human-in-the-Loop Design
-                  span.skill-tag.ai-skill AI Workflow Automation
 
               .skills-container.product-skills
-                h6 Product Management Skills
+                h6 Product Management
                 .skills-grid
                   span.skill-tag.product-skill Product Strategy
-                  span.skill-tag.product-skill Product Portfolio Management
+                  span.skill-tag.product-skill Portfolio Management
                   span.skill-tag.product-skill Team Leadership
                   span.skill-tag.product-skill People Management
                   span.skill-tag.product-skill Cross-functional Leadership
-                  span.skill-tag.product-skill Strategic Planning
-                  span.skill-tag.product-skill Resource Allocation
                   span.skill-tag.product-skill Stakeholder Management
-                  span.skill-tag.product-skill Business Strategy
                   span.skill-tag.product-skill AI/ML Product Development
-                  span.skill-tag.product-skill AI Prototyping
-                  span.skill-tag.product-skill Generative AI
-                  span.skill-tag.product-skill Chatbots
                   span.skill-tag.product-skill Legal Tech
                   span.skill-tag.product-skill Enterprise SaaS
                   span.skill-tag.product-skill User Research
-                  span.skill-tag.product-skill Product Roadmapping
                   span.skill-tag.product-skill Agile Methodologies
-                  span.skill-tag.product-skill Data-Driven Decision Making
                   span.skill-tag.product-skill Go-to-Market Strategy
-                  span.skill-tag.product-skill Performance Management
-                  span.skill-tag.product-skill Budget Management
-                  span.skill-tag.product-skill Vendor Management
                   span.skill-tag.product-skill OKRs & KPIs
 
               .skills-container.engineering-skills
-                h6 Engineering & Technical Skills
+                h6 Engineering & Technical
                 .skills-grid
+                  span.skill-tag.engineering-skill Python
                   span.skill-tag.engineering-skill JavaScript
                   span.skill-tag.engineering-skill Java
-                  span.skill-tag.engineering-skill C
                   span.skill-tag.engineering-skill Swift
-                  span.skill-tag.engineering-skill Python
                   span.skill-tag.engineering-skill React.js
                   span.skill-tag.engineering-skill Vue.js
                   span.skill-tag.engineering-skill Node.js
-                  span.skill-tag.engineering-skill Express.js
                   span.skill-tag.engineering-skill SQL/MySQL
                   span.skill-tag.engineering-skill Azure Cloud
                   span.skill-tag.engineering-skill REST APIs
                   span.skill-tag.engineering-skill Git
-                  span.skill-tag.engineering-skill HTML/CSS
-                  span.skill-tag.engineering-skill Data Modeling
                   span.skill-tag.engineering-skill CI/CD
-                  span.skill-tag.engineering-skill API Integration
-                  span.skill-tag.engineering-skill Database Design
-                  span.skill-tag.engineering-skill Cloud Architecture
-                  span.skill-tag.engineering-skill Technical Documentation
-                  span.skill-tag.engineering-skill Code Review
                   span.skill-tag.engineering-skill System Design
+
+          .portfolio-bio
+            p
+              | As Group Product Manager at Ontra for our flagship product, Contract Automation, I champion innovation through agentic AI solutions — building systems where LLMs autonomously orchestrate complex, multi-step legal workflows — and robust product management. I believe great products come from high-trust teams with clear outcomes and room to create. The teams I lead excel at turning complex customer problems into shipped, impactful solutions.
+            p
+              | I invest in people: candid feedback, visible expectations, and career coaching are baked into our operating rhythms. The result is a culture that experiments, has freedom to fail, learns quickly, and consistently delivers business impact. Known for my inspiring leadership style and clear communication, I ensure that our products exceed customer expectations through strategic product vision and execution on that vision.
+            p
+              | My technical acumen and background in business and legal domains allow me to adeptly navigate complex challenges, giving me a unique edge in crafting product strategy. I actively build with agentic AI frameworks like LangChain, LangGraph, and Claude Agents, bridging PM strategy and hands-on AI engineering in a way few product leaders can. My management style empowers teams to excel, fostering a culture of transparency, innovation, and relentless pursuit of excellence.
+            p
+              | Outside the office, I'm an avid hiker, runner, and reader, with a particular fondness for Walter Isaacson's biography of Leonardo Da Vinci. I also love spending time with my husband, attending concerts, and spending quality time with our family Labradoodle, Koda.
 
   script.
     document.addEventListener('DOMContentLoaded', function() {
-      // Apply styling for skills sections
       const inlineStyles = `
         .about-heading {
           margin-bottom: 0.5rem;
@@ -110,116 +86,129 @@ block content
           color: #fff;
           letter-spacing: 0.5px;
         }
-        
-        .about-subtitle {
-          margin-bottom: 2rem;
-          opacity: 0.8;
-        }
-        
+
         .portfolio-bio {
           background: rgba(255, 255, 255, 0.03);
           border-radius: 8px;
-          padding: 25px;
+          padding: 30px;
           box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
           border: 1px solid rgba(255, 255, 255, 0.05);
           margin-bottom: 20px;
         }
-        
+
         .portfolio-bio p {
           margin-bottom: 1.5rem;
           line-height: 1.7;
           color: rgba(255, 255, 255, 0.85);
+          max-width: 100%;
+          border-bottom: none;
+          padding-bottom: 0;
         }
-        
+
         .portfolio-bio p:last-child {
           margin-bottom: 0;
         }
-        
+
+        .skills-section {
+          margin-top: 0.5rem;
+          margin-bottom: 20px;
+        }
+
+        .skills-columns {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 16px;
+        }
+
+        @media (max-width: 768px) {
+          .skills-columns {
+            grid-template-columns: 1fr;
+          }
+        }
+
         .skills-container {
           background: rgba(255, 255, 255, 0.03);
           border-radius: 8px;
-          padding: 25px;
+          padding: 16px;
           box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
           border: 1px solid rgba(255, 255, 255, 0.05);
-          margin-bottom: 20px;
         }
-        
+
         .skills-container.product-skills {
-          border-left: 3px solid #00a6ff;
+          border-top: 3px solid #00a6ff;
         }
-        
+
         .skills-container.engineering-skills {
-          border-left: 3px solid #00cc66;
+          border-top: 3px solid #00cc66;
         }
 
         .skills-container.ai-skills {
-          border-left: 3px solid #a855f7;
+          border-top: 3px solid #a855f7;
         }
-        
+
         .skills-container h6 {
-          margin-bottom: 15px;
+          margin-bottom: 12px;
           font-weight: 600;
           color: #fff;
           letter-spacing: 0.5px;
+          font-size: 0.85rem;
           display: flex;
           align-items: center;
         }
-        
+
         .skills-container.product-skills h6::before {
-          content: "👨‍💼";
+          content: "\\1F468\\200D\\1F4BC";
           margin-right: 8px;
-          font-size: 1.1rem;
+          font-size: 1rem;
         }
-        
+
         .skills-container.engineering-skills h6::before {
-          content: "👨‍💻";
+          content: "\\1F468\\200D\\1F4BB";
           margin-right: 8px;
-          font-size: 1.1rem;
+          font-size: 1rem;
         }
 
         .skills-container.ai-skills h6::before {
-          content: "🤖";
+          content: "\\1F916";
           margin-right: 8px;
-          font-size: 1.1rem;
+          font-size: 1rem;
         }
-        
+
         .skills-grid {
           display: flex;
           flex-wrap: wrap;
-          gap: 10px;
+          gap: 6px;
         }
-        
+
         .skill-tag {
-          padding: 6px 12px;
+          padding: 4px 10px;
           border-radius: 4px;
-          font-size: 0.85rem;
+          font-size: 0.75rem;
           font-weight: 500;
           transition: all 0.3s ease;
           cursor: default;
         }
-        
+
         .skill-tag.product-skill {
           background: rgba(0, 166, 255, 0.1);
           color: rgba(255, 255, 255, 0.9);
           border: 1px solid rgba(0, 166, 255, 0.2);
         }
-        
+
         .skill-tag.product-skill:hover {
           background: rgba(0, 166, 255, 0.2);
-          transform: translateY(-2px);
-          box-shadow: 0 3px 10px rgba(0, 166, 255, 0.15);
+          transform: translateY(-1px);
         }
-        
+
         .skill-tag.engineering-skill {
           background: rgba(0, 204, 102, 0.1);
           color: rgba(255, 255, 255, 0.9);
           border: 1px solid rgba(0, 204, 102, 0.2);
         }
-        
+
         .skill-tag.engineering-skill:hover {
           background: rgba(0, 204, 102, 0.2);
-          transform: translateY(-2px);
-          box-shadow: 0 3px 10px rgba(0, 204, 102, 0.15);
+          transform: translateY(-1px);
         }
 
         .skill-tag.ai-skill {
@@ -230,11 +219,10 @@ block content
 
         .skill-tag.ai-skill:hover {
           background: rgba(168, 85, 247, 0.2);
-          transform: translateY(-2px);
-          box-shadow: 0 3px 10px rgba(168, 85, 247, 0.15);
+          transform: translateY(-1px);
         }
       `;
-      
+
       const styleElement = document.createElement('style');
       styleElement.textContent = inlineStyles;
       document.head.appendChild(styleElement);

--- a/views/index.pug
+++ b/views/index.pug
@@ -14,6 +14,7 @@ block content
 
   .portfolio-tabs
     a.portfolio-tab(href="#" data-tab="product") Product Management
+    a.portfolio-tab(href="#" data-tab="ai") AI & Machine Learning
     a.portfolio-tab(href="#" data-tab="engineering") Software Engineering
 
   article.grid-container.portfolio-index#portfolioContent
@@ -34,7 +35,24 @@ block content
                   .tech-tags
                     each tech in project.technologies
                       span.tech-tag= tech
-      
+
+      //- AI & Machine Learning Section
+      .portfolio-content.hidden(data-content="ai")
+        each subcategory in aiSubcategories
+          - const subcatProjects = aiProjects.filter(p => p.aiSubcategory === subcategory.id)
+          if subcatProjects.length > 0
+            .category-section
+              .category-header
+                h3= subcategory.name
+              .projects-grid
+                each project in subcatProjects
+                  a.cell(href=`/project/${project.id}`)
+                    img.thumbnail(src=project.image_urls[0] alt=`${project.project_name} - AI/ML Project` loading="lazy")
+                    h5= project.project_name
+                    .tech-tags
+                      each tech in project.technologies
+                        span.tech-tag= tech
+
       //- Engineering Section
       .portfolio-content.hidden(data-content="engineering")
         each category in categories


### PR DESCRIPTION
…yout

Separate AI projects into their own tab on the projects page with three subcategories: Agentic AI & GenAI, Deep Learning & Computer Vision, and Classical AI & Algorithms. Redesign bio page skills from a long sidebar to a compact full-width 3-column grid above the bio text.