### PR TITLE
Fix blueish tint on projects page and add sidebar chat nav item

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -215,11 +215,7 @@ a:hover{
 .portfolio-intro {
   margin: 0;
   padding: 3rem 3rem 2rem;
-  background: linear-gradient(
-    to bottom,
-    var(--dark-surface),
-    var(--dark-surface-2)
-  );
+  background: linear-gradient(to bottom, var(--dark-surface), var(--dark-surface-2));
   position: relative;
   overflow: hidden;
 }
@@ -271,16 +267,16 @@ a:hover{
     padding-bottom: 2rem;
     transition: all 0.7s cubic-bezier(0.4, 0, 0.2, 1);
     border: 1px solid rgba(0, 166, 255, 0.1);
-    box-shadow: 
+    box-shadow:
       0 4px 6px rgba(0, 0, 0, 0.1),
       0 0 0 1px rgba(255, 255, 255, 0.05);
     position: relative;
     z-index: 1003;
   }
-  
+
   .portfolio-index .cell:hover {
     transform: translateY(-8px) scale(1.02);
-    box-shadow: 
+    box-shadow:
       0 20px 40px rgba(0, 166, 255, 0.3),
       0 0 0 2px rgba(0, 166, 255, 0.4),
       0 0 50px rgba(0, 166, 255, 0.2);
@@ -1136,11 +1132,7 @@ a:not(.button):not(.portfolio-index .cell a):hover::after {
 .portfolio-intro {
   margin: 0;
   padding: 3rem 3rem 2rem;
-  background: linear-gradient(
-    to bottom,
-    var(--dark-surface),
-    var(--dark-surface-2)
-  );
+  background: linear-gradient(to bottom, var(--dark-surface), var(--dark-surface-2));
   position: relative;
   overflow: hidden;
 }
@@ -1246,7 +1238,7 @@ a:not(.button):not(.portfolio-index .cell a):hover::after {
   z-index: -1;
 }
 
-/* Add transition overlay effect */
+/* Transition overlay effect removed - was causing blueish tint */
 .portfolio-content::before {
   content: '';
   position: absolute;
@@ -1254,15 +1246,14 @@ a:not(.button):not(.portfolio-index .cell a):hover::after {
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(135deg, var(--accent), transparent);
+  background: none;
   opacity: 0;
-  transition: opacity 0.3s ease;
   pointer-events: none;
   z-index: 1;
 }
 
 .portfolio-content.transitioning::before {
-  opacity: 0.05;
+  opacity: 0;
 }
 
 /* Enhance project card transitions */
@@ -1574,7 +1565,7 @@ a:not(.button):not(.portfolio-index .cell a):hover::after {
   padding: 1.5rem;
   transition: all 0.7s cubic-bezier(0.4, 0, 0.2, 1);
   border: 1px solid rgba(99, 102, 241, 0.1);
-  box-shadow: 
+  box-shadow:
     0 4px 6px rgba(0, 0, 0, 0.1),
     0 0 0 1px rgba(255, 255, 255, 0.05);
   text-decoration: none;
@@ -1588,7 +1579,7 @@ a:not(.button):not(.portfolio-index .cell a):hover::after {
 
 .projects-grid a.cell:hover {
   transform: translateY(-8px) scale(1.02);
-  box-shadow: 
+  box-shadow:
     0 20px 40px rgba(99, 102, 241, 0.3),
     0 0 0 2px rgba(99, 102, 241, 0.4),
     0 0 50px rgba(99, 102, 241, 0.2);
@@ -3599,5 +3590,12 @@ img.blog-logo {
 #chat-toggle:hover,
 #chat-widget.open #chat-toggle {
   animation: none;
+}
+
+/* Sidebar chat trigger */
+.sidebar-chat-trigger {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
 }
 

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -121,6 +121,9 @@ html(class="no-js" lang="en" dir="ltr")
               a.sidebar-nav-button(href='/consuming')
                 .nav-icon 📚
                 .nav-text Currently Consuming
+              a.sidebar-nav-button.sidebar-chat-trigger(href='#' id='sidebar-chat-trigger')
+                .nav-icon 💬
+                .nav-text Chat with Cam's AI Agent
 
           .cell.shrink
             .social-links
@@ -148,7 +151,7 @@ html(class="no-js" lang="en" dir="ltr")
 
     //- Floating Chat Widget (Career Agent)
     #chat-widget
-      button#chat-toggle(aria-label="Chat with Cam's AI Assistant")
+      button#chat-toggle(aria-label="Chat with Cam's AI Agent")
         svg.chat-icon(xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round")
           path(d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z")
         svg.close-icon(xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round")
@@ -156,7 +159,7 @@ html(class="no-js" lang="en" dir="ltr")
           line(x1="6" y1="6" x2="18" y2="18")
       #chat-panel
         .chat-panel-header
-          span Chat with Cam's AI Assistant
+          span Chat with Cam's AI Agent
           button#chat-close(aria-label="Close chat")
             svg(xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round")
               line(x1="18" y1="6" x2="6" y2="18")
@@ -258,6 +261,15 @@ html(class="no-js" lang="en" dir="ltr")
           closeBtn.addEventListener('click', function() {
             closeChat();
           });
+
+          // Sidebar nav trigger
+          var sidebarTrigger = document.getElementById('sidebar-chat-trigger');
+          if (sidebarTrigger) {
+            sidebarTrigger.addEventListener('click', function(e) {
+              e.preventDefault();
+              openChat();
+            });
+          }
 
           // Close on Escape key
           document.addEventListener('keydown', function(e) {


### PR DESCRIPTION
Remove blue gradient overlay (.portfolio-content::before) that was causing a blueish tint behind project cards which changed intensity across tabs. Add sidebar navigation item for chat widget and rename to "Cam's AI Agent".